### PR TITLE
feat: use functions of std library with `using`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,16 @@
 version = 3
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "katastrophe"
 version = "0.3.0"
 dependencies = [
+ "indoc",
  "once_cell",
  "paste",
 ]
@@ -18,6 +25,6 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+indoc = "2.0.5"
 once_cell = "1.19.0"
 paste = "1.0.14"

--- a/README.md
+++ b/README.md
@@ -11,23 +11,49 @@ $ cargo build
 
 To try out Katastrophe, here is an example code in Katastrophe. save it as a file `test.katas` in current directory.
 ```
-def add(x, y) -> i32 {
-    return x + y;
-}
+using std::io::getchar;
+using std::io::putchar;
 
-def sub(x, y) -> i32 {
-    return x - y;
+let newline as i32 = 10;
+let char_0 as i32 = 48;
+let char_9 as i32 = 57;
+
+def print_number(x as i32) {
+    if x <= 9 {
+        putchar(char_0 + x);
+        return;
+    }
+    print_number(x / 10);
+    putchar(char_0 + (x - x / 10 * 10));
 }
 
 def main() -> i32 {
-    let a = add(1, 1);
-    let b = sub(5, 4);
-    let c = add(a, b);
-    return a + b + c;
+    # read number
+    let mut x as i32 = 0;
+    let mut c as i32 = getchar();
+    while c != newline {
+        if char_0 <= c && c <= char_9 {
+            x = x * 10 + (c - char_0);
+        } else {
+            return -1;
+        }
+        c = getchar();
+    }
+
+    # print doubled x
+    x = 2 * x;
+    if x == 0 {
+        putchar(char_0);
+    } else {
+        print_number(x);
+    }
+    putchar(10);
+    return 0;
 }
+
 ```
 
 To compile `test.katas`, just run
 ```shell
-$ cargo run
+$ cargo run -- test.katas -o test
 ```

--- a/library/std/io.katas
+++ b/library/std/io.katas
@@ -1,0 +1,7 @@
+def builtin getchar() -> i32 {
+    # builtin
+}
+
+def builtin putchar(c as i32) -> bool {
+    # builtin
+}

--- a/library/std/io/builtin/getchar.ll
+++ b/library/std/io/builtin/getchar.ll
@@ -1,0 +1,4 @@
+define i32 {value}() {
+    %c = call i32 @getchar()
+    ret i32 %c
+}

--- a/library/std/io/builtin/putchar.ll
+++ b/library/std/io/builtin/putchar.ll
@@ -1,0 +1,5 @@
+define i1 {value}(i32 %c) {
+    %putchar_result = call i32 @putchar(i32 %c)
+    %compare_result = icmp eq i32 %putchar_result, -1
+    ret i1 %compare_result
+}

--- a/library/std/process.katas
+++ b/library/std/process.katas
@@ -1,0 +1,3 @@
+def exit(exit_status as i32) {
+    # builtin.
+}

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -3,5 +3,6 @@ pub mod ir;
 pub mod lexis;
 pub mod semantics;
 pub mod syntax;
+pub mod context;
 
 mod scope;

--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use crate::define_id_generator;
+
+use super::ir::instruction::{Instruction, IrModel};
+use super::syntax::ast::crumb::{Identifier, Mutability};
+use super::syntax::ast::package::DocumentPath;
+use super::syntax::ast::ty::Type;
+use super::syntax::ast::Document;
+
+pub type DocumentId = u32;
+
+pub struct Context {
+    pub id_map: HashMap<DocumentPath, DocumentId>,
+    pub path_map: HashMap<DocumentId, DocumentPath>,
+    pub document_map: HashMap<DocumentId, Document>,
+    pub type_map: HashMap<DocumentId, HashMap<Identifier, Type>>,
+    pub mutability_map: HashMap<DocumentId, HashMap<Identifier, Mutability>>,
+    pub ir_model_map: HashMap<DocumentId, HashMap<Identifier, IrModel>>,
+    pub instruction: HashMap<DocumentId, Instruction>,
+}
+
+impl Context {
+    pub fn new() -> Context {
+        Context {
+            id_map: HashMap::new(),
+            path_map: HashMap::new(),
+            document_map: HashMap::new(),
+            type_map: HashMap::new(),
+            mutability_map: HashMap::new(),
+            ir_model_map: HashMap::new(),
+            instruction: HashMap::new(),
+        }
+    }
+}
+
+define_id_generator!(document, pub);

--- a/src/compiler/ir.rs
+++ b/src/compiler/ir.rs
@@ -1,6 +1,6 @@
+pub mod builtin;
 pub mod instruction;
 pub mod translator;
 
-mod builtin;
 mod err;
 mod id;

--- a/src/compiler/ir/builtin.rs
+++ b/src/compiler/ir/builtin.rs
@@ -1,21 +1,46 @@
 use std::fs;
 
-use crate::compiler::{err::CompileError, scope::Tag};
+use crate::compiler::err::CompileError;
 
-use super::{err::IrError, instruction::IrScope};
+use super::{
+    err::IrError,
+    instruction::{ir_type::IrType, Instruction, IrFunctionPrototype, Value},
+};
 
-pub fn init_builtin_scope(
-    scope: &mut IrScope,
-    code_builder: &mut String,
-) -> Result<(), CompileError> {
-    scope.enter(Tag::Builtin);
-    let builtin = fs::read_to_string("static/builtin.ll")
-        .or::<CompileError>(Err(IrError::BuiltinFileNotExist.into()))?;
-    code_builder.push_str(&builtin);
-    Ok(())
+pub fn generate_builtin() -> Result<Instruction, CompileError> {
+    match fs::read_to_string("static/builtin.ll") {
+        Ok(code) => Ok(Instruction::BuiltinDefinition(code)),
+        Err(_) => Err(IrError::BuiltinFileNotExist.into()),
+    }
 }
 
-pub fn deinit_builtin_scope(scope: &mut IrScope) -> Result<(), CompileError> {
-    scope.leave(Tag::Builtin)?;
-    Ok(())
+pub fn generate_entry(main_value: Value) -> Result<Instruction, CompileError> {
+    let template = Instruction::Definition(
+        IrFunctionPrototype {
+            function_type: IrType::Function {
+                return_type: Box::new(IrType::I32),
+                parameter_types: Vec::new(),
+            },
+            id: Value::Function("main".to_string()),
+        },
+        Vec::new(),
+        Box::new(Instruction::Batch(vec![
+            Instruction::Call {
+                receiver: Some(Value::Register("main_return".to_string())),
+                function: IrFunctionPrototype {
+                    function_type: IrType::Function {
+                        return_type: Box::new(IrType::I32),
+                        parameter_types: Vec::new(),
+                    },
+                    id: main_value,
+                },
+                arguments: Vec::new(),
+            },
+            Instruction::Return {
+                return_type: IrType::I32,
+                value: Value::Register("main_return".to_string()),
+            },
+        ])),
+    );
+    Ok(template)
 }

--- a/src/compiler/ir/err.rs
+++ b/src/compiler/ir/err.rs
@@ -1,8 +1,8 @@
 use crate::{compiler::err::InnerCompilerError, util::reportable_error::ReportableError};
 
 pub enum IrError {
-    UndefinedMain,
     BuiltinFileNotExist,
+    BuiltinFunctionFileNotExist(String),
 }
 
 impl InnerCompilerError for IrError {}
@@ -10,11 +10,11 @@ impl InnerCompilerError for IrError {}
 impl ReportableError for IrError {
     fn report(&self) -> ! {
         match &self {
-            IrError::UndefinedMain => {
-                panic!("main function not found in global scope.");
-            }
             IrError::BuiltinFileNotExist => {
                 panic!("builtin file not exist.");
+            }
+            IrError::BuiltinFunctionFileNotExist(identifier) => {
+                panic!("builtin function {identifier} file not exist")
             }
         }
     }

--- a/src/compiler/ir/instruction.rs
+++ b/src/compiler/ir/instruction.rs
@@ -9,7 +9,9 @@ use self::ir_type::IrType;
 
 pub mod ir_type;
 
-pub type IrScope = Scope<(Value, IrType)>;
+pub type IrModel = (Value, IrType);
+
+pub type IrScope = Scope<IrModel>;
 
 #[derive(Clone)]
 pub enum Value {
@@ -119,6 +121,7 @@ pub enum Instruction {
     },
     Batch(Vec<Instruction>),
     Definition(IrFunctionPrototype, Vec<Value>, Box<Instruction>),
+    BuiltinDefinition(String),
     Binary {
         operator: IrBinaryOpcode,
         data_type: IrType,
@@ -132,10 +135,10 @@ pub enum Instruction {
         to: Value,
     },
     Bitcast {
-        from: (Value, IrType),
-        to: (Value, IrType),
+        from: IrModel,
+        to: IrModel,
     },
-    Allocate(Value, IrType),
+    Allocate(IrModel),
     Load {
         data_type: IrType,
         from: Value,
@@ -283,6 +286,7 @@ impl PrettyFormat for Instruction {
                 Ok(())
             }
             Instruction::Definition(_, _, _) => self.format_definition(f, indentation_num),
+            Instruction::BuiltinDefinition(ir_code) => writeln!(f, "{ir_code}"),
             Instruction::Binary {
                 operator,
                 data_type,
@@ -309,7 +313,7 @@ impl PrettyFormat for Instruction {
                     "{indentation}{to_value} = bitcast {from_type} {from_value} to {to_type}"
                 )
             }
-            Instruction::Allocate(pointer, data_type) => {
+            Instruction::Allocate((pointer, data_type)) => {
                 writeln!(f, "{indentation}{pointer} = alloca {data_type}")
             }
             Instruction::Load {

--- a/src/compiler/lexis/err.rs
+++ b/src/compiler/lexis/err.rs
@@ -1,4 +1,4 @@
-use crate::util::reportable_error::ReportableError;
+use crate::{compiler::err::InnerCompilerError, util::reportable_error::ReportableError};
 
 pub enum LexErrorKind {
     IllegalIntegerLiteral(String),
@@ -11,6 +11,8 @@ pub enum LexErrorKind {
 pub struct LexError {
     pub kind: LexErrorKind,
 }
+
+impl InnerCompilerError for LexError {}
 
 impl ReportableError for LexError {
     fn report(&self) -> ! {

--- a/src/compiler/lexis/token.rs
+++ b/src/compiler/lexis/token.rs
@@ -12,6 +12,7 @@ pub enum Keyword {
     While,
     As,
     Mut,
+    Builtin,
 }
 
 static KEYWORD_MAP: Lazy<HashMap<&'static str, Keyword>> = Lazy::new(|| {
@@ -26,6 +27,7 @@ static KEYWORD_MAP: Lazy<HashMap<&'static str, Keyword>> = Lazy::new(|| {
             ("while", Keyword::While),
             ("as", Keyword::As),
             ("mut", Keyword::Mut),
+            ("builtin", Keyword::Builtin),
         ]
         .map(|(s, k)| (s, k)),
     )
@@ -74,6 +76,7 @@ pub enum Symbol {
 
     Comma,
     Semicolon,
+    DoubleColon,
 
     Arrow,
 }
@@ -86,6 +89,5 @@ pub enum Token {
     BoolLiteral(bool),
 
     Keyword(Keyword),
-
     Symbol(Symbol),
 }

--- a/src/compiler/semantics.rs
+++ b/src/compiler/semantics.rs
@@ -1,4 +1,5 @@
 pub mod mutability_checker;
 pub mod type_inferrer;
+pub mod main_function_check;
 
 mod err;

--- a/src/compiler/semantics/err.rs
+++ b/src/compiler/semantics/err.rs
@@ -45,6 +45,9 @@ pub enum TypeError {
         parameter_types: Vec<Type>,
         argument_types: Vec<Type>,
     },
+
+    UndeclaredMainFunction,
+    IllegalMainFunctionType,
 }
 
 impl InnerCompilerError for TypeError {}
@@ -95,6 +98,12 @@ impl ReportableError for TypeError {
                 argument types: {argument_types}"
                 )
             }
+            TypeError::UndeclaredMainFunction => {
+                panic!("main function not declared in input document.")
+            },
+            TypeError::IllegalMainFunctionType => {
+                panic!("the type of main function must be () -> i32.")
+            },
         }
     }
 }

--- a/src/compiler/semantics/main_function_check.rs
+++ b/src/compiler/semantics/main_function_check.rs
@@ -1,0 +1,26 @@
+use crate::compiler::{
+    context::{Context, DocumentId},
+    err::CompileError,
+    syntax::ast::ty::Type,
+};
+
+use super::err::TypeError;
+
+pub fn main_function_check(
+    context: &Context,
+    main_document_id: DocumentId,
+) -> Result<(), CompileError> {
+    let type_map = context.type_map.get(&main_document_id).unwrap();
+    let main_type = match type_map.get(&String::from("main")) {
+        Some(main_type) => main_type,
+        None => return Err(TypeError::UndeclaredMainFunction.into()),
+    };
+    let expected_main_function_type = Type::Function {
+        return_type: Box::new(Type::I32),
+        parameter_types: Vec::new(),
+    };
+    if main_type != &expected_main_function_type {
+        return Err(TypeError::IllegalMainFunctionType.into());
+    }
+    Ok(())
+}

--- a/src/compiler/syntax/ast.rs
+++ b/src/compiler/syntax/ast.rs
@@ -1,21 +1,23 @@
 use core::fmt;
+
 use std::fmt::Display;
 
 use crate::util::pretty_format::PrettyFormat;
 
-use self::{statement::Statement, ty::Type};
+use self::statement::Statement;
 
 pub mod crumb;
 pub mod expression;
 pub mod operator;
+pub mod package;
 pub mod statement;
 pub mod ty;
 
-pub struct Program {
+pub struct Document {
     pub statements: Vec<Statement>,
 }
 
-impl PrettyFormat for Program {
+impl PrettyFormat for Document {
     fn pretty_format(&self, f: &mut fmt::Formatter, indentation_num: usize) -> fmt::Result {
         self.statements
             .iter()
@@ -23,7 +25,7 @@ impl PrettyFormat for Program {
     }
 }
 
-impl Display for Program {
+impl Display for Document {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.pretty_format(f, 0)
     }

--- a/src/compiler/syntax/ast/crumb.rs
+++ b/src/compiler/syntax/ast/crumb.rs
@@ -2,7 +2,9 @@ use std::fmt::{self, Display};
 
 use super::ty::Type;
 
-pub struct Parameter(pub String);
+pub type Identifier = String;
+
+pub struct Parameter(pub Identifier);
 
 impl Display for Parameter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -12,7 +14,7 @@ impl Display for Parameter {
 }
 
 pub struct FunctionPrototype {
-    pub identifier: String,
+    pub identifier: Identifier,
     pub parameters: Vec<Parameter>,
     pub function_type: Type,
 }
@@ -32,4 +34,4 @@ impl Display for Mutability {
     }
 }
 
-pub struct Variable(pub String, pub Type, pub Mutability);
+pub struct Variable(pub Identifier, pub Type, pub Mutability);

--- a/src/compiler/syntax/ast/expression.rs
+++ b/src/compiler/syntax/ast/expression.rs
@@ -2,13 +2,15 @@ use std::fmt::{self, Display};
 
 use crate::util::pretty_format::{indent, PrettyFormat};
 
+use crate::compiler::syntax::ast::ty::Type;
+
 use super::{
+    crumb::Identifier,
     operator::{Binary, Unary},
-    Type,
 };
 
 pub enum Expression {
-    Identifier(String),
+    Identifier(Identifier),
 
     IntLiteral(i32),
     FloatLiteral(f64),
@@ -17,7 +19,7 @@ pub enum Expression {
     Unary(Unary, Type, Box<Expression>),
     Binary(Binary, Type, Box<Expression>, Box<Expression>),
 
-    Call(String, Vec<Expression>),
+    Call(Identifier, Vec<Expression>),
 }
 
 impl PrettyFormat for Expression {

--- a/src/compiler/syntax/ast/package.rs
+++ b/src/compiler/syntax/ast/package.rs
@@ -1,0 +1,92 @@
+use std::{
+    fmt::{self, Display},
+    fs,
+};
+
+use crate::compiler::{
+    context::Context,
+    err::CompileError,
+    ir::instruction::Value,
+    syntax::{
+        err::{ParseError, ParseErrorKind},
+        parser::Parser,
+    },
+};
+
+use super::crumb::Identifier;
+
+pub type PathNode = String;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct DocumentPath(pub Vec<PathNode>);
+
+impl DocumentPath {
+    pub fn to_dir(&self) -> String {
+        let DocumentPath(path_nodes) = self;
+        path_nodes.iter().cloned().collect::<Vec<_>>().join("/")
+    }
+}
+
+impl Display for DocumentPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let DocumentPath(path_nodes) = self;
+        let formatted = path_nodes.iter().cloned().collect::<Vec<_>>().join("::");
+        write!(f, "{formatted}")
+    }
+}
+
+pub struct UsingPath(pub DocumentPath, pub Identifier);
+
+impl Display for UsingPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let UsingPath(document_path, item) = self;
+        write!(f, "{document_path}::{item}")
+    }
+}
+
+pub fn load_package_path(context: &mut Context, path: &DocumentPath) -> Result<(), CompileError> {
+    if context.id_map.contains_key(path) {
+        return Ok(());
+    }
+    load_package(context, path)?;
+    Ok(())
+}
+
+pub fn get_builtin(path: &DocumentPath, id: &String, value: &Value) -> Option<String> {
+    let document_path = get_package_path(path);
+    let file_path = format!("{document_path}/builtin/{id}.ll");
+    match fs::read_to_string(file_path) {
+        Ok(code) => Some(code.replace("{value}", value.to_string().as_str())),
+        Err(_) => None,
+    }
+}
+
+fn get_package_path(document_path: &DocumentPath) -> String {
+    let DocumentPath(path_nodes) = document_path;
+    let root_directory = &path_nodes[0];
+    match root_directory.as_str() {
+        "std" => get_std_package_path(document_path),
+        _ => todo!(),
+    }
+}
+
+fn get_std_package_path(document_path: &DocumentPath) -> String {
+    const STD_ROOT: &'static str = "./library";
+    let dir = document_path.to_dir();
+    format!("{STD_ROOT}/{dir}")
+}
+
+fn load_package(context: &mut Context, path: &DocumentPath) -> Result<(), CompileError> {
+    let file_path = get_package_path(path) + ".katas";
+    let code = match fs::read_to_string(file_path) {
+        Ok(code) => code,
+        Err(_) => {
+            return Err(ParseError {
+                kind: ParseErrorKind::UnknownPackage,
+            }
+            .into());
+        }
+    };
+    Parser::new(path.clone(), &code).parse_document(context)?;
+    Ok(())
+}

--- a/src/compiler/syntax/err.rs
+++ b/src/compiler/syntax/err.rs
@@ -15,6 +15,7 @@ pub enum ParseErrorKind {
     UnexpectedToken(Token),
 
     UnknownType(String),
+    UnknownPackage,
 }
 
 pub struct ParseError {
@@ -25,21 +26,24 @@ impl InnerCompilerError for ParseError {}
 
 impl ReportableError for ParseError {
     fn report(&self) -> ! {
-        let message = match self.kind {
+        let message = match &self.kind {
             ParseErrorKind::MissingIdentifier => "failed to expect an identifier".to_string(),
-            ParseErrorKind::MissingKeyword(ref keyword) => {
+            ParseErrorKind::MissingKeyword(keyword) => {
                 format!("missing expected keyword: {keyword:?}")
             }
-            ParseErrorKind::MissingSymbol(ref symbol) => {
+            ParseErrorKind::MissingSymbol(symbol) => {
                 format!("missing expected symbol: {symbol:?}")
             }
             ParseErrorKind::UnexpectedEOF => "encountering unexpected EOF".to_string(),
-            ParseErrorKind::UnexpectedToken(ref token) => {
+            ParseErrorKind::UnexpectedToken(token) => {
                 format!("encountering unexpected token: {token:?}")
             }
-            ParseErrorKind::UnknownType(ref unknown_type) => {
+            ParseErrorKind::UnknownType(unknown_type) => {
                 format!("encountering unknown type: {unknown_type}")
             }
+            ParseErrorKind::UnknownPackage => {
+                format!("unknown package.")
+            },
         };
         panic!("{message}")
     }

--- a/static/builtin.ll
+++ b/static/builtin.ll
@@ -1,4 +1,3 @@
 declare i32 @exit(i32)
 declare i32 @getchar()
 declare i32 @putchar(i32)
-


### PR DESCRIPTION
It is now possible to import std library
functions using the `using` keyword.
For example, to import the getchar function:
```
using std::io::getchar;

def main() -> i32 {
    let c = getchar();
    return 0;
}
```

Current shortcomings:
1. Various concepts (packages, paths, document) are somewhat disorganized.
2. The std standard library is currently placed in the directory of this compiler. If the project improves in the future, package managers for Linux, like apt, may be used, which would necessitate changes.
3. There is currently no implementation for importing other documents in the working directory (i.e., multi-file compilation), nor for importing third-party libraries.