### PR TITLE
feat: `using` imports a 'reference' now

### DIFF
--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -7,9 +7,8 @@ use super::ir::instruction::Instruction;
 use super::ir::instruction::IrModel;
 use super::syntax::ast::Document;
 use super::syntax::ast::crumb::Identifier;
-use super::syntax::ast::crumb::Mutability;
 use super::syntax::ast::package::DocumentPath;
-use super::syntax::ast::ty::Type;
+use super::syntax::ast::reference::Reference;
 
 pub type DocumentId = u32;
 
@@ -17,8 +16,7 @@ pub struct Context {
     pub id_map: HashMap<Rc<DocumentPath>, DocumentId>,
     pub path_map: HashMap<DocumentId, Rc<DocumentPath>>,
     pub document_map: HashMap<DocumentId, Document>,
-    pub type_map: HashMap<DocumentId, HashMap<Rc<Identifier>, Rc<Type>>>,
-    pub mutability_map: HashMap<DocumentId, HashMap<Rc<Identifier>, Mutability>>,
+    pub reference_map: HashMap<DocumentId, HashMap<Rc<Identifier>, Rc<Reference>>>,
     pub ir_model_map: HashMap<DocumentId, HashMap<Rc<Identifier>, IrModel>>,
     pub instruction: HashMap<DocumentId, Rc<Instruction>>,
 }
@@ -30,8 +28,7 @@ impl Context {
             id_map: HashMap::new(),
             path_map: HashMap::new(),
             document_map: HashMap::new(),
-            type_map: HashMap::new(),
-            mutability_map: HashMap::new(),
+            reference_map: HashMap::new(),
             ir_model_map: HashMap::new(),
             instruction: HashMap::new(),
         }

--- a/src/compiler/semantics/main_function_checker.rs
+++ b/src/compiler/semantics/main_function_checker.rs
@@ -1,16 +1,19 @@
+use std::rc::Rc;
+
 use crate::compiler::bit_width::BitWidth;
 use crate::compiler::context::Context;
 use crate::compiler::context::DocumentId;
 use crate::compiler::err::CompileError;
+use crate::compiler::syntax::ast::reference::Reference;
 use crate::compiler::syntax::ast::ty::Type;
 use crate::sys_error;
 
 /// # Errors
 pub fn main_function_check(context: &Context, main_document_id: DocumentId) -> Result<(), CompileError> {
-    let Some(type_map) = context.type_map.get(&main_document_id) else {
-        sys_error!("type map must exist");
+    let Some(reference_map) = context.reference_map.get(&main_document_id) else {
+        sys_error!("reference map must exist");
     };
-    let Some(main_type) = type_map.get(&String::from("main")) else {
+    let Some(Reference::Binding(main_type, _)) = reference_map.get(&String::from("main")).map(Rc::as_ref) else {
         return Err(CompileError::UndeclaredMainFunction);
     };
     let expected_main_function_type = Type::Function {

--- a/src/compiler/semantics/mutability_checker.rs
+++ b/src/compiler/semantics/mutability_checker.rs
@@ -12,6 +12,7 @@ use crate::compiler::syntax::ast::crumb::Variable;
 use crate::compiler::syntax::ast::expression::Expression;
 use crate::compiler::syntax::ast::operator::Binary;
 use crate::compiler::syntax::ast::package::UsingPath;
+use crate::compiler::syntax::ast::reference::Reference;
 use crate::compiler::syntax::ast::statement::DefineDetail;
 use crate::compiler::syntax::ast::statement::LetDetail;
 use crate::compiler::syntax::ast::statement::Statement;
@@ -107,9 +108,10 @@ impl MutabilityChecker {
             },
             Statement::Using(UsingPath(document_path, symbol)) => {
                 let id = context.id_map.get(document_path).unwrap();
-                let Some(mutability) = context.mutability_map.get(id).unwrap().get(symbol) else {
+                let Some(reference) = context.reference_map.get(id).unwrap().get(symbol) else {
                     sys_error!("used symbol must exist");
                 };
+                let Reference::Binding(_, mutability) = reference.as_ref();
                 self.scope.declare(symbol.clone(), *mutability)?;
                 Ok(())
             }

--- a/src/compiler/semantics/type_inferrer.rs
+++ b/src/compiler/semantics/type_inferrer.rs
@@ -15,6 +15,7 @@ use crate::compiler::syntax::ast::expression::Expression;
 use crate::compiler::syntax::ast::operator::Binary;
 use crate::compiler::syntax::ast::operator::Unary;
 use crate::compiler::syntax::ast::package::UsingPath;
+use crate::compiler::syntax::ast::reference::Reference;
 use crate::compiler::syntax::ast::statement::DefineDetail;
 use crate::compiler::syntax::ast::statement::IfDetail;
 use crate::compiler::syntax::ast::statement::LetDetail;
@@ -357,8 +358,8 @@ impl TypeInferrer {
             }) => self.infer_define_statement(context, prototype, body)?,
             Statement::Using(UsingPath(document_path, symbol)) => {
                 let used_document_id = context.id_map.get(document_path).unwrap();
-                let type_map = context.type_map.get(used_document_id).unwrap();
-                let Some(symbol_type) = type_map.get(symbol) else {
+                let reference_map = context.reference_map.get(used_document_id).unwrap();
+                let Some(Reference::Binding(symbol_type, _)) = reference_map.get(symbol).map(Rc::as_ref) else {
                     sys_error!("used symbol must exist");
                 };
                 self.scope.declare(symbol.clone(), symbol_type.clone())?;

--- a/src/compiler/syntax/ast.rs
+++ b/src/compiler/syntax/ast.rs
@@ -11,6 +11,7 @@ pub mod crumb;
 pub mod expression;
 pub mod operator;
 pub mod package;
+pub mod reference;
 pub mod statement;
 pub mod ty;
 

--- a/src/compiler/syntax/ast/reference.rs
+++ b/src/compiler/syntax/ast/reference.rs
@@ -1,0 +1,7 @@
+use std::rc::Rc;
+
+use super::{crumb::Mutability, ty::Type};
+
+pub enum Reference {
+    Binding(Rc<Type>, Mutability),
+}


### PR DESCRIPTION
We will soon use `using` to import both bindings and struct definitions, so they must be distinguished by packaged in a 'reference' enum.